### PR TITLE
Feature/disable magento default cron

### DIFF
--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -19,5 +19,8 @@
         <job name="kuzman_auto_order_cancel" instance="Kuzman\AutoOrderCancel\Cron\CancelOrders" method="execute">
             <schedule>*/5 * * * *</schedule>
         </job>
+        <job name="sales_clean_orders" instance="Magento\Sales\Model\CronJob\CleanExpiredOrders" method="execute">
+            <schedule>0 0 30 2 *</schedule>
+        </job>
     </group>
 </config>


### PR DESCRIPTION
Magento 2 has a cron which only cleans pending_payment orders every hour.

Unfortunately, Magento 2 doesn't have an option like disable = "true", we have to move it to a non-existent date 
https://devdocs.magento.com/guides/v2.4/config-guide/cron/custom-cron-ref.html#disable-cron-job